### PR TITLE
Add Tree Fertilizer support for fruit trees

### DIFF
--- a/UltimateFertilizer/ExposedAPI.cs
+++ b/UltimateFertilizer/ExposedAPI.cs
@@ -15,4 +15,12 @@ public class ExposedApi : IUltimateFertilizerApi {
     public void RegisterFertilizerType(IEnumerable<string> itemIds) {
         ModEntry.Fertilizers.Add(itemIds.ToList());
     }
+
+    public bool FertilizeFruitTree(FruitTree tree) {
+        return ModEntry.FruitTreeSupport.Fertilize(tree);
+    }
+
+    public bool IsFruitTreeFertilized(FruitTree tree) {
+        return ModEntry.FruitTreeSupport.IsFertilized(tree);
+    }
 }

--- a/UltimateFertilizer/IUltimateFertilizerApi.cs
+++ b/UltimateFertilizer/IUltimateFertilizerApi.cs
@@ -21,4 +21,13 @@ public interface IUltimateFertilizerApi {
     /// <param name="itemIds">A collection of fertilizer itemIds that are considered same type.</param>
     /// <remarks>The fertilizer should be tiered from low to high.</remarks>
     void RegisterFertilizerType(IEnumerable<string> itemIds);
+
+    /// <summary>Apply Tree Fertilizer to a fruit tree (the vanilla game ignores fruit trees).</summary>
+    /// <param name="tree">The fruit tree instance.</param>
+    /// <returns>Whether the fruit tree was fertilized (false if it was already fertilized or fully grown).</returns>
+    bool FertilizeFruitTree(FruitTree tree);
+
+    /// <summary>Check whether a fruit tree has been fertilized by this mod.</summary>
+    /// <param name="tree">The fruit tree instance.</param>
+    bool IsFruitTreeFertilized(FruitTree tree);
 }

--- a/UltimateFertilizer/ModEntry.cs
+++ b/UltimateFertilizer/ModEntry.cs
@@ -40,6 +40,17 @@ namespace UltimateFertilizer {
 
             public List<float> FertilizerWaterRetentionBoost = new() {0.33f, 0.66f, 1.0f};
             public List<int> FertilizerWaterRetentionAmount = new() {1, 2, 1};
+
+            // Tree Fertilizer on fruit trees (vanilla ignores fruit trees entirely).
+            public bool EnableFruitTreeFertilizer = true;
+            public bool FruitTreeGrowAnywhere = true;
+
+            // On application, immediately reduce the tree's remaining days-to-mature by
+            // this percentage (50 = cut the remaining time in half). 0 disables it.
+            public int FruitTreeMatureBoostPercent = 50;
+
+            // Optional ongoing per-day maturity gain (1 = vanilla speed; off by default).
+            public int FruitTreeGrowthRate = 1;
         }
 
         private static Config _config = null!;
@@ -144,6 +155,42 @@ namespace UltimateFertilizer {
                 tooltip: () => _helper.Translation.Get("config.debug_mode.tooltip"),
                 getValue: () => _config.PrintDebugMode,
                 setValue: value => _config.PrintDebugMode = value
+            );
+
+            configMenu.AddSectionTitle(mod: ModManifest,
+                text: () => _helper.Translation.Get("config.section.fruit_tree"));
+            configMenu.AddBoolOption(
+                mod: ModManifest,
+                name: () => _helper.Translation.Get("config.fruit_tree_enable.title"),
+                tooltip: () => _helper.Translation.Get("config.fruit_tree_enable.tooltip"),
+                getValue: () => _config.EnableFruitTreeFertilizer,
+                setValue: value => _config.EnableFruitTreeFertilizer = value
+            );
+            configMenu.AddBoolOption(
+                mod: ModManifest,
+                name: () => _helper.Translation.Get("config.fruit_tree_grow_anywhere.title"),
+                tooltip: () => _helper.Translation.Get("config.fruit_tree_grow_anywhere.tooltip"),
+                getValue: () => _config.FruitTreeGrowAnywhere,
+                setValue: value => _config.FruitTreeGrowAnywhere = value
+            );
+            configMenu.AddNumberOption(
+                mod: ModManifest,
+                name: () => _helper.Translation.Get("config.fruit_tree_mature_boost.title"),
+                tooltip: () => _helper.Translation.Get("config.fruit_tree_mature_boost.tooltip"),
+                getValue: () => _config.FruitTreeMatureBoostPercent,
+                setValue: value => _config.FruitTreeMatureBoostPercent = Math.Max(0, Math.Min(value, 100)),
+                min: 0,
+                max: 100,
+                interval: 5
+            );
+            configMenu.AddNumberOption(
+                mod: ModManifest,
+                name: () => _helper.Translation.Get("config.fruit_tree_growth_rate.title"),
+                tooltip: () => _helper.Translation.Get("config.fruit_tree_growth_rate.tooltip"),
+                getValue: () => _config.FruitTreeGrowthRate,
+                setValue: value => _config.FruitTreeGrowthRate = Math.Max(1, Math.Min(value, 7)),
+                min: 1,
+                max: 7
             );
 
             configMenu.AddSectionTitle(mod: ModManifest,
@@ -299,6 +346,255 @@ namespace UltimateFertilizer {
         public static void Print(string msg) {
             if (_config.PrintDebugMode) {
                 _logger?.Log(msg, LogLevel.Debug);
+            }
+        }
+
+        /// <summary>Tree Fertilizer support for fruit trees (vanilla only fertilizes wild trees).</summary>
+        public static class FruitTreeSupport {
+            public const string ModDataKey = "fox_white25.ultimate_fertilizer/TreeFertilized";
+            public const string TreeFertilizerQID = "(O)805";
+
+            public enum HandleResult {
+                /// <summary>Not a fertilizable target / feature disabled — let vanilla handle the click.</summary>
+                NotApplicable,
+                /// <summary>The tree was just fertilized on this click.</summary>
+                Fertilized,
+                /// <summary>Rejected (already fertilized); feedback shown.</summary>
+                Rejected,
+                /// <summary>Already processed earlier in the same click; do nothing.</summary>
+                AlreadyHandled
+            }
+
+            // Per-click dedupe: a single click can route through performUseAction and
+            // placementAction (sometimes more than once). We only want to act once.
+            private static Vector2 _lastTile = new(float.MinValue, float.MinValue);
+            private static int _lastTick = int.MinValue;
+
+            public static bool IsFertilized(FruitTree tree) {
+                return tree.modData.TryGetValue(ModDataKey, out var value) && value == "true";
+            }
+
+            /// <summary>Apply the fertilized state and the immediate maturity cut. No UI/sound.</summary>
+            private static void ApplyFertilizer(FruitTree tree) {
+                tree.modData[ModDataKey] = "true";
+
+                // Immediately cut the remaining time-to-mature (default: halve it).
+                var pct = Math.Clamp(_config.FruitTreeMatureBoostPercent, 0, 100);
+                if (pct > 0 && tree.daysUntilMature.Value > 0) {
+                    var newDays = (int) Math.Ceiling(tree.daysUntilMature.Value * (1.0 - pct / 100.0));
+                    tree.daysUntilMature.Value = newDays;
+                    tree.growthStage.Value = FruitTree.DaysUntilMatureToGrowthStage(newDays);
+                }
+
+                Print($"Fruit tree fertilized at {tree.Tile}; daysUntilMature now {tree.daysUntilMature.Value}");
+            }
+
+            /// <summary>
+            /// API helper: mark a fruit tree fertilized (no UI). Mirrors <see cref="Tree.fertilize"/>
+            /// rejection rules. Returns true if it was newly fertilized.
+            /// </summary>
+            public static bool Fertilize(FruitTree tree) {
+                if (tree.growthStage.Value >= FruitTree.treeStage || IsFertilized(tree)) {
+                    return false;
+                }
+
+                ApplyFertilizer(tree);
+                return true;
+            }
+
+            /// <summary>
+            /// Handle a click on a fruit tree while holding Tree Fertilizer. Deduped so the
+            /// multiple dispatch paths for one click only take effect once.
+            /// </summary>
+            public static HandleResult HandleInteraction(FruitTree tree) {
+                if (!_config.EnableFruitTreeFertilizer) {
+                    return HandleResult.NotApplicable;
+                }
+
+                // Fully grown: nothing to fertilize — let vanilla shake/harvest happen.
+                if (tree.growthStage.Value >= FruitTree.treeStage) {
+                    return HandleResult.NotApplicable;
+                }
+
+                var tile = tree.Tile;
+                if (_lastTile == tile && Game1.ticks - _lastTick <= 1) {
+                    return HandleResult.AlreadyHandled;
+                }
+
+                _lastTile = tile;
+                _lastTick = Game1.ticks;
+
+                if (IsFertilized(tree)) {
+                    Game1.showRedMessageUsingLoadString("Strings\\StringsFromCSFiles:TreeFertilizer2");
+                    tree.Location?.playSound("cancel");
+                    return HandleResult.Rejected;
+                }
+
+                ApplyFertilizer(tree);
+                tree.Location?.playSound("dirtyHit");
+                return HandleResult.Fertilized;
+            }
+        }
+
+        /// <summary>
+        /// A fruit tree consumes the click to shake itself (performUseAction returns true),
+        /// which happens before placement logic. When the player is holding Tree Fertilizer
+        /// and the tree can be fertilized, take over the click here instead of shaking.
+        /// This is the path that actually fires for left-click / use-tool-button.
+        /// </summary>
+        [HarmonyPatch(typeof(FruitTree), nameof(FruitTree.performUseAction))]
+        public static class FruitTreeUseAction {
+            public static bool Prefix(FruitTree __instance, ref bool __result) {
+                if (!_config.EnableFruitTreeFertilizer) {
+                    return true;
+                }
+
+                var who = Game1.player;
+                var active = who?.ActiveObject;
+                if (who == null || active == null || active.QualifiedItemId != FruitTreeSupport.TreeFertilizerQID) {
+                    return true;
+                }
+
+                // Fully grown: let vanilla handle it (shake / harvest fruit).
+                if (__instance.growthStage.Value >= FruitTree.treeStage) {
+                    return true;
+                }
+
+                var result = FruitTreeSupport.HandleInteraction(__instance);
+                if (result == FruitTreeSupport.HandleResult.NotApplicable) {
+                    return true;
+                }
+
+                if (result == FruitTreeSupport.HandleResult.Fertilized) {
+                    who.reduceActiveItemByOne();
+                }
+
+                __result = true; // click handled; don't shake
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Controller / right-click "place item" path: the click reaches placementAction
+        /// instead of performUseAction. Handle Tree Fertilizer on a fruit tree here too.
+        /// </summary>
+        [HarmonyPatch(typeof(Object), nameof(Object.placementAction))]
+        public static class FruitTreeFertilizerPlacement {
+            public static void Postfix(Object __instance, GameLocation location, int x, int y, ref bool __result) {
+                if (__result || !_config.EnableFruitTreeFertilizer) {
+                    return;
+                }
+
+                if (__instance.QualifiedItemId != FruitTreeSupport.TreeFertilizerQID || location == null) {
+                    return;
+                }
+
+                var tile = new Vector2(x / 64, y / 64);
+                if (location.terrainFeatures.GetValueOrDefault(tile) is not FruitTree fruitTree) {
+                    return;
+                }
+
+                if (fruitTree.growthStage.Value >= FruitTree.treeStage) {
+                    return;
+                }
+
+                // Only signal success (which makes the game consume one Tree Fertilizer)
+                // when we actually fertilized on this click. Rejected / already-handled
+                // leave __result false so the item isn't consumed.
+                if (FruitTreeSupport.HandleInteraction(fruitTree) == FruitTreeSupport.HandleResult.Fertilized) {
+                    __result = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Allow Tree Fertilizer (O)805 to be placed on a fruit-tree tile. Vanilla's
+        /// canBePlacedHere only returns true when the tile holds a wild <see cref="Tree"/>,
+        /// so without this the click is rejected (red tile) and placementAction never runs.
+        /// </summary>
+        [HarmonyPatch(typeof(Object), nameof(Object.canBePlacedHere))]
+        public static class FruitTreeFertilizerPlaceable {
+            public static void Postfix(Object __instance, GameLocation l, Vector2 tile, ref bool __result) {
+                if (__result || !_config.EnableFruitTreeFertilizer) {
+                    return;
+                }
+
+                if (__instance.QualifiedItemId != "(O)805" || l == null) {
+                    return;
+                }
+
+                // Mirror vanilla's wild-tree behaviour: allow placement over any fruit tree;
+                // the "already fertilized / too grown" rejection is handled in placementAction.
+                if (l.terrainFeatures.GetValueOrDefault(tile) is FruitTree) {
+                    __result = true;
+                }
+            }
+        }
+
+        /// <summary>True when the player is currently holding a fruit-tree sapling, i.e. these
+        /// clearance checks are running for a placement attempt rather than overnight growth.</summary>
+        private static bool IsPlacingFruitTreeSapling() {
+            return _config.EnableFruitTreeFertilizer
+                   && _config.FruitTreeGrowAnywhere
+                   && Game1.player?.ActiveObject?.IsFruitTreeSapling() == true;
+        }
+
+        /// <summary>
+        /// Fruit trees ignore the surrounding-clearance requirement entirely when "grow anywhere"
+        /// is on. Vanilla calls this both at placement (canBePlacedHere / placementAction) and
+        /// during overnight growth (dayUpdate), so neutralizing it here lets saplings be planted
+        /// in crowded spots *and* keeps them growing there afterwards.
+        /// </summary>
+        [HarmonyPatch(typeof(FruitTree), nameof(FruitTree.IsGrowthBlocked))]
+        public static class FruitTreeGrowthBlocked {
+            public static bool Prefix(ref bool __result) {
+                if (!_config.EnableFruitTreeFertilizer || !_config.FruitTreeGrowAnywhere) {
+                    return true;
+                }
+
+                __result = false; // never blocked by crowding
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Let fruit-tree saplings be planted right next to other trees. Vanilla rejects placement
+        /// within 2 tiles of any tree via IsTooCloseToAnotherTree; bypass it while the player is
+        /// holding a sapling and "grow anywhere" is on.
+        /// </summary>
+        [HarmonyPatch(typeof(FruitTree), nameof(FruitTree.IsTooCloseToAnotherTree))]
+        public static class FruitTreeTooClose {
+            public static bool Prefix(ref bool __result) {
+                if (!IsPlacingFruitTreeSapling()) {
+                    return true;
+                }
+
+                __result = false;
+                return false;
+            }
+        }
+
+        /// <summary>Speed up maturation of fertilized fruit trees by temporarily raising their growth rate.</summary>
+        [HarmonyPatch(typeof(FruitTree), nameof(FruitTree.dayUpdate))]
+        public static class FruitTreeDayUpdate {
+            public static void Prefix(FruitTree __instance, out int __state) {
+                __state = int.MinValue;
+                if (!_config.EnableFruitTreeFertilizer || _config.FruitTreeGrowthRate <= 1) {
+                    return;
+                }
+
+                if (__instance.growthStage.Value >= FruitTree.treeStage || !FruitTreeSupport.IsFertilized(__instance)) {
+                    return;
+                }
+
+                __state = __instance.growthRate.Value;
+                __instance.growthRate.Value = _config.FruitTreeGrowthRate;
+            }
+
+            public static void Postfix(FruitTree __instance, int __state) {
+                if (__state != int.MinValue) {
+                    __instance.growthRate.Value = __state;
+                }
             }
         }
 

--- a/UltimateFertilizer/i18n/de.json
+++ b/UltimateFertilizer/i18n/de.json
@@ -31,6 +31,21 @@
   "config.debug_mode.tooltip": "Aktiviere Debug-Ausgabe zur Konsole",
 
 
+  "config.section.fruit_tree": "Baumdünger auf Obstbäumen",
+
+  "config.fruit_tree_enable.title": "Bei Obstbäumen aktivieren",
+  "config.fruit_tree_enable.tooltip": "Erlaubt, Baumdünger (den für Wildbäume) auch auf Obstbäume anzuwenden. Im Originalspiel werden Obstbäume ignoriert.",
+
+  "config.fruit_tree_grow_anywhere.title": "Überall pflanzen & wachsen",
+  "config.fruit_tree_grow_anywhere.tooltip": "Obstbäume ignorieren die Abstandsregel: Setzlinge können an beengten Stellen gepflanzt werden (neben anderen Bäumen, Objekten, Wegen oder Pflanzen) und wachsen dort weiter. Erfordert 'Bei Obstbäumen aktivieren'.",
+
+  "config.fruit_tree_mature_boost.title": "Reife-Sprung bei Anwendung (%)",
+  "config.fruit_tree_mature_boost.tooltip": "Reduziert beim Düngen eines Obstbaums sofort die verbleibenden Tage bis zur Reife um diesen Prozentsatz. 50 = halbiert die verbleibende Zeit (ein Baum mit 14 Tagen springt auf 7). 100 = sofort reif. 0 = kein Soforteffekt.",
+
+  "config.fruit_tree_growth_rate.title": "Laufende Reifegeschwindigkeit",
+  "config.fruit_tree_growth_rate.tooltip": "Extra: Reifetage, die ein gedüngter Obstbaum JEDEN Tag zusätzlich zum einmaligen Sprung oben gewinnt. 1 = normale Geschwindigkeit (aus). 2 = reift künftig doppelt so schnell. Bis zu 7. Bei 1 lassen, wenn nur der einmalige Sprung gewünscht ist.",
+
+
   "config.section.speed_fertilizer": "Geschwindigkeits Dünger",
   
   "config.affect_multi_harvest.title": "Betrifft Pflanzen mit mehreren Ernten",

--- a/UltimateFertilizer/i18n/default.json
+++ b/UltimateFertilizer/i18n/default.json
@@ -31,6 +31,21 @@
   "config.debug_mode.tooltip": "Enable debug output to console",
 
 
+  "config.section.fruit_tree": "Tree Fertilizer on Fruit Trees",
+
+  "config.fruit_tree_enable.title": "Enable on Fruit Trees",
+  "config.fruit_tree_enable.tooltip": "Allow Tree Fertilizer (the wild-tree one) to also be applied to fruit trees. Vanilla ignores fruit trees entirely.",
+
+  "config.fruit_tree_grow_anywhere.title": "Plant & Grow Anywhere",
+  "config.fruit_tree_grow_anywhere.tooltip": "Fruit trees ignore the surrounding-clearance rule: saplings can be planted in crowded spots (next to other trees, objects, paths or crops) and keep growing there. Requires 'Enable on Fruit Trees'.",
+
+  "config.fruit_tree_mature_boost.title": "Maturity Cut on Apply (%)",
+  "config.fruit_tree_mature_boost.tooltip": "When you fertilize a fruit tree, immediately reduce its remaining days-to-mature by this percent. 50 = cut the remaining time in half (a tree with 14 days left jumps to 7). 100 = mature instantly. 0 = no immediate effect.",
+
+  "config.fruit_tree_growth_rate.title": "Ongoing Maturation Rate",
+  "config.fruit_tree_growth_rate.tooltip": "Extra: days of maturity a fertilized fruit tree gains EACH day, on top of the one-time cut above. 1 = vanilla speed (off). 2 = matures twice as fast going forward. Up to 7. Leave at 1 if you only want the one-time cut.",
+
+
   "config.section.speed_fertilizer": "Speed Fertilizer",
   
   "config.affect_multi_harvest.title": "Affect Multi-Harvest",

--- a/UltimateFertilizer/i18n/ko.json
+++ b/UltimateFertilizer/i18n/ko.json
@@ -31,6 +31,21 @@
   "config.debug_mode.tooltip": "콘솔에 디버그 출력 활성화",
 
 
+  "config.section.fruit_tree": "과일나무에 나무 비료 적용",
+
+  "config.fruit_tree_enable.title": "과일나무에 적용",
+  "config.fruit_tree_enable.tooltip": "나무 비료(야생 나무용)를 과일나무에도 사용할 수 있게 합니다. 기본 게임은 과일나무를 무시합니다.",
+
+  "config.fruit_tree_grow_anywhere.title": "어디서나 심고 성장",
+  "config.fruit_tree_grow_anywhere.tooltip": "과일나무가 주변 공간 규칙을 무시합니다: 묘목을 비좁은 곳(다른 나무, 물건, 길, 작물 옆)에도 심을 수 있고 그곳에서 계속 자랍니다. '과일나무에 적용'이 필요합니다.",
+
+  "config.fruit_tree_mature_boost.title": "적용 시 성숙 단축 (%)",
+  "config.fruit_tree_mature_boost.tooltip": "과일나무에 비료를 주면 성숙까지 남은 일수를 이 비율만큼 즉시 줄입니다. 50 = 남은 시간을 절반으로 (14일 남은 나무가 7일로). 100 = 즉시 성숙. 0 = 즉시 효과 없음.",
+
+  "config.fruit_tree_growth_rate.title": "지속 성숙 속도",
+  "config.fruit_tree_growth_rate.tooltip": "추가: 비료를 준 과일나무가 위의 일회성 단축에 더해 매일 얻는 성숙 일수. 1 = 기본 속도(꺼짐). 2 = 이후 두 배 빠르게 성숙. 최대 7. 일회성 단축만 원하면 1로 두세요.",
+
+
   "config.section.speed_fertilizer": "성장 촉진제",
   
   "config.affect_multi_harvest.title": "다수 수확에 영향 주기",

--- a/UltimateFertilizer/i18n/pt.json
+++ b/UltimateFertilizer/i18n/pt.json
@@ -29,8 +29,23 @@
   
   "config.debug_mode.title": "Debug Mod",
   "config.debug_mode.tooltip": "Habilitar saída de depuração para o console",
-  
-  
+
+
+  "config.section.fruit_tree": "Fertilizante de Árvore em Árvores Frutíferas",
+
+  "config.fruit_tree_enable.title": "Ativar em Árvores Frutíferas",
+  "config.fruit_tree_enable.tooltip": "Permite aplicar o Fertilizante de Árvore (o das árvores selvagens) também em árvores frutíferas. O jogo base ignora árvores frutíferas.",
+
+  "config.fruit_tree_grow_anywhere.title": "Plantar e Crescer em Qualquer Lugar",
+  "config.fruit_tree_grow_anywhere.tooltip": "Árvores frutíferas ignoram a regra de espaço ao redor: mudas podem ser plantadas em locais apertados (ao lado de outras árvores, objetos, caminhos ou plantações) e continuam crescendo ali. Requer 'Ativar em Árvores Frutíferas'.",
+
+  "config.fruit_tree_mature_boost.title": "Corte de Maturação ao Aplicar (%)",
+  "config.fruit_tree_mature_boost.tooltip": "Ao fertilizar uma árvore frutífera, reduz imediatamente os dias restantes para amadurecer nesta porcentagem. 50 = corta pela metade o tempo restante (uma árvore com 14 dias passa para 7). 100 = amadurece na hora. 0 = sem efeito imediato.",
+
+  "config.fruit_tree_growth_rate.title": "Taxa de Maturação Contínua",
+  "config.fruit_tree_growth_rate.tooltip": "Extra: dias de maturação que uma árvore frutífera fertilizada ganha A CADA dia, além do corte único acima. 1 = velocidade normal (desligado). 2 = amadurece duas vezes mais rápido daqui em diante. Até 7. Deixe em 1 se quiser apenas o corte único.",
+
+
   "config.section.speed_fertilizer": "Fertilizante de Velocidade",
   
   "config.affect_multi_harvest.title": "Afeta Multi-Colheita",

--- a/UltimateFertilizer/i18n/zh.json
+++ b/UltimateFertilizer/i18n/zh.json
@@ -31,6 +31,21 @@
   "config.debug_mode.tooltip": "启用调试输出到控制台",
 
 
+  "config.section.fruit_tree": "果树施用树木肥料",
+
+  "config.fruit_tree_enable.title": "对果树启用",
+  "config.fruit_tree_enable.tooltip": "允许将树木肥料（用于野生树木的那种）也施用于果树。原版游戏会完全忽略果树。",
+
+  "config.fruit_tree_grow_anywhere.title": "随处种植与生长",
+  "config.fruit_tree_grow_anywhere.tooltip": "果树将忽略周围空间限制：树苗可以种在拥挤的位置（紧挨其他树木、物体、道路或作物），并能在那里继续生长。需要启用“对果树启用”。",
+
+  "config.fruit_tree_mature_boost.title": "施用时成熟度削减 (%)",
+  "config.fruit_tree_mature_boost.tooltip": "为果树施肥时，立即按此百分比减少其剩余成熟天数。50 = 剩余时间减半（剩 14 天的树变为 7 天）。100 = 立即成熟。0 = 无即时效果。",
+
+  "config.fruit_tree_growth_rate.title": "持续成熟速度",
+  "config.fruit_tree_growth_rate.tooltip": "额外：已施肥的果树在上面的一次性削减之外，每天额外获得的成熟天数。1 = 原版速度（关闭）。2 = 之后成熟速度翻倍。最高 7。若只想要一次性削减，请保持为 1。",
+
+
   "config.section.speed_fertilizer": "生长激素",
 
   "config.affect_multi_harvest.title": "影响多次收获",


### PR DESCRIPTION
This adds the optional "Tree Fertilizer works on fruit trees" feature we discussed in #5. Thanks again for the go-ahead.

It is purely additive and does not touch any existing fertilizer logic. Everything is gated behind a new config section (and the master "Enable on Fruit Trees" toggle), defaulting on.

## What it does
- Lets the wild-tree Tree Fertilizer (O)805 be applied to fruit trees, which vanilla ignores entirely.
- On application, immediately cuts the tree's remaining days-to-mature by a configurable percentage (default 50%).
- Optional ongoing maturation rate: a fertilized fruit tree can gain extra maturity each day (default off / vanilla speed).
- "Plant & Grow Anywhere": fruit trees ignore the surrounding-clearance and 2-tile proximity rules, so saplings can be planted in crowded spots and keep growing there (this also fixes trees stalling overnight in tight spaces).

## Implementation notes
- New `FruitTreeSupport` static class plus attributed Harmony patches (`FruitTree.performUseAction`, `Object.placementAction`, `Object.canBePlacedHere`, `FruitTree.IsGrowthBlocked`, `FruitTree.IsTooCloseToAnotherTree`, `FruitTree.dayUpdate`). They register through your existing `_harmony.PatchAll()`.
- Two new API methods: `FertilizeFruitTree(FruitTree)` and `IsFruitTreeFertilized(FruitTree)`.
- Config keys added to all i18n locales (default, de, ko, pt, zh).
- The fertilized flag is stored in modData under the mod's UniqueID.
- I left `manifest.json` Version and MinimumApiVersion unchanged for you to set. One heads up: the current 3.0.0 floor is already lower than the 1.6 APIs the mod uses, in case you want to bump it.

Built cleanly against the current code with no changes to existing behavior. Happy to adjust anything to fit your preferences.
